### PR TITLE
Check dependencies license and bundle the report with in the plugin jar

### DIFF
--- a/archive-task-helper.gradle
+++ b/archive-task-helper.gradle
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
- allprojects { eachProject ->
+allprojects { eachProject ->
   eachProject.afterEvaluate {
     // generate checksums for all archives
     tasks.withType(AbstractArchiveTask) { archiveTask ->

--- a/default-allowed-licenses.json
+++ b/default-allowed-licenses.json
@@ -1,0 +1,20 @@
+{
+  "allowedLicenses": [
+    {
+      "moduleLicense": "MIT License",
+      "moduleName": ".*"
+    },
+    {
+      "moduleLicense": "MIT.*",
+      "moduleName": ".*"
+    },
+    {
+      "moduleLicense": "Apache License, Version 2.0",
+      "moduleName": ".*"
+    },
+    {
+      "moduleLicense": ".*Apache.*2.0",
+      "moduleName": ".*"
+    }
+  ]
+}

--- a/helper.gradle
+++ b/helper.gradle
@@ -13,28 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-buildscript {
-  repositories {
-    gradlePluginPortal()
-  }
 
-  dependencies {
-    classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
-  }
+buildscript {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    dependencies {
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
+    }
 }
 
-
 subprojects {
-  apply plugin: 'java'
+    apply plugin: 'java'
 
-  sourceCompatibility = 1.8
-  targetCompatibility = 1.8
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 }
 
 task allDependencies {
-  dependsOn allprojects.collect { "$it.path:dependencies" }
+    dependsOn allprojects.collect { "$it.path:dependencies" }
 
-  description = "Print dependency tree of all projects"
+    description = "Print dependency tree of all projects"
 }
 
 apply plugin: com.github.benmanes.gradle.versions.VersionsPlugin

--- a/license-normalizer-bundle.json
+++ b/license-normalizer-bundle.json
@@ -1,0 +1,27 @@
+{
+  "bundles": [
+    {
+      "bundleName": "apache2",
+      "licenseName": "Apache License, Version 2.0",
+      "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0"
+    }
+  ],
+  "transformationRules": [
+    {
+      "bundleName": "apache2",
+      "licenseNamePattern": ".*The Apache Software License, Version 2.0.*"
+    },
+    {
+      "bundleName": "apache2",
+      "licenseNamePattern": "Apache 2"
+    },
+    {
+      "bundleName": "apache2",
+      "licenseNamePattern": ".*Apache.*2.0.*"
+    },
+    {
+      "bundleName": "apache2",
+      "licenseUrlPattern": "http://www.apache.org/licenses/LICENSE-2.0.txt"
+    }
+  ]
+}

--- a/release-task-helper.gradle
+++ b/release-task-helper.gradle
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+
+import com.github.jk1.license.filter.*
+import com.github.jk1.license.render.*
 import groovy.json.JsonSlurper
 import groovyx.net.http.ContentType
 import groovyx.net.http.HTTPBuilder
@@ -21,12 +25,14 @@ import groovyx.net.http.ParserRegistry
 
 buildscript {
   repositories {
+    gradlePluginPortal()
     mavenCentral()
   }
 
   dependencies {
     classpath localGroovy()
     classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
+    classpath 'com.github.jk1:gradle-license-report:1.7'
   }
 }
 
@@ -37,7 +43,18 @@ class GitHubRepository {
   String token
 }
 
+class Report {
+  String outputDir
+  List<Project> projects
+  List<String> configurations = ["compile"]
+  List<String> excludeGroups = []
+  List<String> excludes = []
+  boolean excludeOwnGroup = true
+  def importers = []
+}
+
 class GoCDPluginExtension {
+
   String id
   String pluginVersion
   String goCdVersion
@@ -53,10 +70,12 @@ class GoCDPluginExtension {
   Task[] assetsToRelease
 
   final GitHubRepository githubRepo
+  final Report licenseReport
 
   @javax.inject.Inject
   GoCDPluginExtension(ObjectFactory objectFactory) {
     githubRepo = objectFactory.newInstance(GitHubRepository)
+    licenseReport = objectFactory.newInstance(Report)
   }
 
   String fullVersion(Project project) {
@@ -65,6 +84,10 @@ class GoCDPluginExtension {
 
   void githubRepo(Action<? super GitHubRepository> action) {
     action.execute(githubRepo)
+  }
+
+  void licenseReport(Action<? super Report> action) {
+    action.execute(licenseReport)
   }
 }
 
@@ -88,7 +111,9 @@ class ReleaseTask extends DefaultTask {
     def changelogHeader = lastTag ? "### Changelog ${lastTag}..${lastCommit.substring(0, 7)}" : "### Changelog"
     def changeLog = project.git.getCommitsSinceLastTag(lastTag).replaceAll("\"", "")
     def supportedGoCDVersionNote = "**Note:** *Supported GoCD server version: ${project.gocdPlugin.goCdVersion} or above.*"
-    def checksumNote = """**SHA256 Checksums**\n```\n${sha256Sums.collect({ File eachFile -> eachFile.getText("utf-8").trim() }).join("\n")}\n```""".trim()
+    def checksumNote = """**SHA256 Checksums**\n```\n${
+      sha256Sums.collect({ File eachFile -> eachFile.getText("utf-8").trim() }).join("\n")
+    }\n```""".trim()
     def tagName = project.extensions.gocdPlugin.prerelease ? "${gocdPlugin.fullVersion(project)}-exp" : gocdPlugin.fullVersion(project)
 
 
@@ -199,14 +224,56 @@ class ReleaseTask extends DefaultTask {
 
 }
 
+project.rootProject.ext.defaultAllowedLicenses = writeTempFile("./default-allowed-licenses.json")
+project.rootProject.ext.licenseNormalizerBundle = writeTempFile("./license-normalizer-bundle.json")
+
 class GoCDPlugin implements Plugin<Project> {
   void apply(Project project) {
+    project.configure(project) {
+      project.allprojects { apply plugin: com.github.jk1.license.LicenseReportPlugin }
+    }
+
     GoCDPluginExtension gocdPluginExtension = project.extensions.create('gocdPlugin', GoCDPluginExtension)
 
-    project.tasks.create('githubRelease', ReleaseTask) { ReleaseTask thisTask ->
-      thisTask.dependsOn project.allprojects*.tasks*.findByName('assemble').findAll { it != null }
+    project.afterEvaluate {
+      initializeLicenseReporting(gocdPluginExtension, project)
+
+      project.tasks.create('githubRelease', ReleaseTask) { ReleaseTask thisTask ->
+        thisTask.dependsOn project.allprojects*.tasks*.findByName('assemble').findAll { it != null }
+      }
     }
   }
+
+  private void initializeLicenseReporting(GoCDPluginExtension gocdPluginExtension, Project project) {
+    Project pluginProject = gocdPluginExtension.pluginProject
+    pluginProject.tasks.assemble.dependsOn("checkLicense")
+    pluginProject.extensions.licenseReport.outputDir = gocdPluginExtension.licenseReport.outputDir ?: "$project.rootDir/build/license"
+    pluginProject.extensions.licenseReport.projects = gocdPluginExtension.licenseReport.projects ?: project.allprojects
+    pluginProject.extensions.licenseReport.configurations = gocdPluginExtension.licenseReport.configurations ?: ["compile"]
+    pluginProject.extensions.licenseReport.excludeGroups = gocdPluginExtension.licenseReport.excludeGroups
+    pluginProject.extensions.licenseReport.excludeOwnGroup = gocdPluginExtension.licenseReport.excludeOwnGroup
+    pluginProject.extensions.licenseReport.excludes = gocdPluginExtension.licenseReport.excludes
+    pluginProject.extensions.licenseReport.renderers = [new TextReportRenderer()]
+    pluginProject.extensions.licenseReport.importers = gocdPluginExtension.licenseReport.importers
+    pluginProject.extensions.licenseReport.filters = new LicenseBundleNormalizer(bundlePath: project.rootProject.licenseNormalizerBundle)
+    pluginProject.extensions.licenseReport.allowedLicensesFile = project.rootProject.defaultAllowedLicenses
+
+    project.allprojects*.tasks*.findByName('jar').findAll { jar ->
+      if (jar == null) return
+      jar.into('license-report') {
+        from "$pluginProject.extensions.licenseReport.outputDir/THIRD-PARTY-NOTICES.txt"
+      }
+    }
+  }
+}
+
+private File writeTempFile(String fileName) {
+  def content = (buildscript.sourceFile ? buildscript.sourceFile.toURI() : buildscript.sourceURI).resolve(fileName).toURL().text
+  def name = fileName.substring(0, fileName.lastIndexOf('.'))
+  def ext = fileName.substring(fileName.lastIndexOf('.'))
+  File file = File.createTempFile(name, ext)
+  file.write content
+  file
 }
 
 apply plugin: GoCDPlugin


### PR DESCRIPTION
- This will add the license-report/THIRD-PARTY-NOTICES.txt file in the
assembled plugin jar

- As of now allowed licenses are
  * "Apache 2.0"
  * "MIT"

- In case, if plugin requires more licenses please add it to the
  data/default-allowed-licenses.json file and also see if added license
  requires normalization. See data/license-normalizer-bundle.json for
  more information.

- To disable license check
  ```
  gocdPlugin {
   	...
	licenseReport {
		validateDependenciesLicense = false
        }
  }
  ```

> Example output
```
Archive:  gocd-vault-secret-plugin-0.0.1-11.jar
   creating: META-INF/
  inflating: META-INF/MANIFEST.MF
   creating: com/
   creating: com/thoughtworks/
   creating: com/thoughtworks/gocd/
   creating: com/thoughtworks/gocd/secretmanager/
   creating: com/thoughtworks/gocd/secretmanager/vault/
  inflating: com/thoughtworks/gocd/secretmanager/vault/ClientFactory.class
  inflating: com/thoughtworks/gocd/secretmanager/vault/SecretConfigLookupExecutor.class
  inflating: com/thoughtworks/gocd/secretmanager/vault/VaultPlugin.class
   creating: com/thoughtworks/gocd/secretmanager/vault/builders/
  inflating: com/thoughtworks/gocd/secretmanager/vault/builders/VaultConfigBuilder.class
   creating: com/thoughtworks/gocd/secretmanager/vault/models/
  inflating: com/thoughtworks/gocd/secretmanager/vault/models/Secret.class
  inflating: com/thoughtworks/gocd/secretmanager/vault/models/SecretConfig.class
  inflating: com/thoughtworks/gocd/secretmanager/vault/models/Secrets.class
   creating: com/thoughtworks/gocd/secretmanager/vault/request/
  inflating: com/thoughtworks/gocd/secretmanager/vault/request/SecretConfigRequest.class
  inflating: plugin-icon.png
  inflating: plugin.properties
  inflating: plugin.xml
  inflating: secrets.template.html
   creating: lib/
  inflating: lib/gocd-plugin-base-0.0.3.jar
  inflating: lib/vault-java-driver-4.0.0.jar
  inflating: lib/gson-2.8.5.jar
  inflating: lib/jackson-databind-2.9.8.jar
  inflating: lib/commons-lang3-3.8.1.jar
  inflating: lib/jackson-annotations-2.9.0.jar
  inflating: lib/jackson-core-2.9.8.jar
   creating: license-report/
  inflating: license-report/THIRD-PARTY-NOTICES.txt
```

> Example notice file

```

Dependency License Report for gocd-file-based-secrets-plugin 0.0.2-23

1. Group: com.beust  Name: jcommander  Version: 1.72

Manifest License: Apache License, Version 2.0 (Not packaged)

POM Project URL: http://jcommander.org

POM License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0

--------------------------------------------------------------------------------

2. Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.9.0

Project URL: http://github.com/FasterXML/jackson

Manifest License: Apache License, Version 2.0 (Not packaged)

POM License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0

Embedded license: 

                    ****************************************                    

This copy of Jackson JSON processor annotations is licensed under the
Apache (Software) License, version 2.0 ("the License").
See the License for details about distribution rights, and the
specific rights regarding derivate works.

You may obtain a copy of the License at:

http://www.apache.org/licenses/LICENSE-2.0

--------------------------------------------------------------------------------

3. Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.9.8

Project URL: https://github.com/FasterXML/jackson-core

Manifest License: Apache License, Version 2.0 (Not packaged)

POM License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0

Embedded license: 

                    ****************************************                    

This copy of Jackson JSON processor streaming parser/generator is licensed under the
Apache (Software) License, version 2.0 ("the License").
See the License for details about distribution rights, and the
specific rights regarding derivate works.

You may obtain a copy of the License at:

http://www.apache.org/licenses/LICENSE-2.0

                    ****************************************                    

# Jackson JSON processor

Jackson is a high-performance, Free/Open Source JSON processing library.
It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
been in development since 2007.
It is currently developed by a community of developers, as well as supported
commercially by FasterXML.com.

## Licensing

Jackson core and extension components may licensed under different licenses.
To find the details that apply to this artifact see the accompanying LICENSE file.
For more information, including possible other licensing options, contact
FasterXML.com (http://fasterxml.com).

## Credits

A list of contributors may be found from CREDITS file, which is included
in some artifacts (usually source distributions); but is always available
from the source code management (SCM) system project uses.

--------------------------------------------------------------------------------
...
```