### PR TITLE
Update regex for mit license to accept " (MIT)" at the end

### DIFF
--- a/license-normalizer-bundle.json
+++ b/license-normalizer-bundle.json
@@ -69,7 +69,7 @@
     { "bundleName" : "LGPL-2.1-only", "licenseNamePattern" : "GNU Lesser General Public License Version 2.1" },
     { "bundleName" : "LGPL-2.1-only", "licenseUrlPattern" : ".*www\\.gnu\\.org/licenses/lgpl-2\\.1\\.html" },
     { "bundleName" : "LGPL-2.1-only", "licenseNamePattern" : "LGPL 2\\.1" },
-    { "bundleName" : "MIT", "licenseNamePattern" : "(The\\s)?MIT(\\s[l|L]icen[c|s]e)?" },
+    { "bundleName" : "MIT", "licenseNamePattern" : "(The\\s)?MIT(\\s[l|L]icen[c|s]e)?(\\s[(]MIT[)])?" },
     { "bundleName" : "MPL-1.1", "licenseNamePattern" : "MPL 1\\.1" },
     { "bundleName" : "Public-Domain", "licenseNamePattern" : "(([p|P]ublic|PUBLIC)\\s([d|D]omain|DOMAIN)).*", "transformUrl" : false },
     { "bundleName" : "Public-Domain", "licenseFileContentPattern" : ".*([c|C]reative|CREATIVE)\\s([c|C]ommons|COMMONS).*", "transformUrl" : false },


### PR DESCRIPTION
 - this is needed for azure elastic agent plugin dependencies