### PR TITLE
Annotate ReleaseHelperTask properties correctly for Gradle 7 compatibility

### DIFF
--- a/release-task-helper.gradle
+++ b/release-task-helper.gradle
@@ -92,9 +92,9 @@ class GoCDPluginExtension {
 }
 
 abstract class ReleaseHelperTask extends DefaultTask {
-  final String HEADER_USER_AGENT = 'gocd-gradle-github-release-plugin'
-  final String GITHUB_API_BASE_URL = "https://api.github.com"
-  final String GITHUB_API_ACCEPT_HEADER = "application/vnd.github.v3+json"
+  @Internal final String HEADER_USER_AGENT = 'gocd-gradle-github-release-plugin'
+  @Internal final String GITHUB_API_BASE_URL = "https://api.github.com"
+  @Internal final String GITHUB_API_ACCEPT_HEADER = "application/vnd.github.v3+json"
 
   protected static HTTPBuilder createHttpBuilder(url) {
     def http = new HTTPBuilder(url)


### PR DESCRIPTION
Plugins using Gradle 7 with these helpers are failing to use the release task, e.g the analytics plugin at https://github.com/gocd/gocd-analytics-plugin/runs/3682741734?check_suite_focus=true 

```
   - Type 'ReleaseTask' property 'GITHUB_API_ACCEPT_HEADER' is missing an input or output annotation.
   - Type 'ReleaseTask' property 'GITHUB_API_BASE_URL' is missing an input or output annotation.
   - Type 'ReleaseTask' property 'HEADER_USER_AGENT' is missing an input or output annotation.
```

After this change it seems to get through further and then fail with credentials (as expected)
```
> Task :githubRelease FAILED
Error in POST /repos/bob/gocd-analytics-plugin/releases
 > User-Agent: gocd-gradle-github-release-plugin
 > Authorization: (not shown)
 > Accept: application/vnd.github.v3+json
 > body: [tag_name:v3.1.0-104-exp, target_commitish:720e657988bc95c0a575f0393fefa41108c1119d, name:Experimental: 3.1.0-104, body:### Changelog v3.1.0-81-exp..720e657

c1e0c51 - Bump mockito-core from 3.10.0 to 3.12.4
78bc4d6 - Bump gson from 2.8.7 to 2.8.8
a5a338e - Bump junit-jupiter-engine from 5.7.2 to 5.8.0
1eeb946 - Bump logback-classic from 1.2.3 to 1.2.6
cd0799a - Bump eslint from 7.27.0 to 7.32.0
d782223 - Bump slf4j-simple from 1.7.30 to 1.7.32
0204eb4 - Bump postgresql from 42.2.20 to 42.2.23
4f8033d - Bump mini-css-extract-plugin from 1.6.0 to 1.6.2
a00d766 - Update Install.md
859b390 - Bump gson from 2.8.6 to 2.8.7
c976984 - Bump mybatis from 3.4.5 to 3.5.7
9020ae4 - Remove deprecated behavior (implicit dependency)
fd574b3 - Gradle 7

**SHA256 Checksums**
70f9ec2cbe873f4a9123fe0297014672724fad863588584711f09ac78a67268f *gocd-analytics-plugin-3.1.0-104.jar
, prerelease:true]


FAILURE: Build failed with an exception.

* Where:
Script 'https://raw.githubusercontent.com/chadlwilson/gocd-plugin-gradle-task-helpers/master/release-task-helper.gradle' line: 214

* What went wrong:
Bad credentials. See https://docs.github.com/rest.
```

Looks like there was an attempt to make these helpers Gradle 7 compatible but it got stuck part way through.

Fixes part of #9 (but not the deprecations)