### PR TITLE
Correct license report generation for multi-project plugins

### DIFF
--- a/release-task-helper.gradle
+++ b/release-task-helper.gradle
@@ -50,6 +50,7 @@ class Report {
   List<String> excludeGroups = []
   List<String> excludes = []
   boolean excludeOwnGroup = true
+  boolean excludeBoms = true
   def importers = []
 }
 
@@ -312,6 +313,7 @@ class GoCDPlugin implements Plugin<Project> {
     pluginProject.extensions.licenseReport.configurations = gocdPluginExtension.licenseReport.configurations ?: ["runtimeClasspath"]
     pluginProject.extensions.licenseReport.excludeGroups = gocdPluginExtension.licenseReport.excludeGroups
     pluginProject.extensions.licenseReport.excludeOwnGroup = gocdPluginExtension.licenseReport.excludeOwnGroup
+    pluginProject.extensions.licenseReport.excludeBoms = gocdPluginExtension.licenseReport.excludeBoms
     pluginProject.extensions.licenseReport.excludes = gocdPluginExtension.licenseReport.excludes
     pluginProject.extensions.licenseReport.renderers = [new TextReportRenderer()]
     pluginProject.extensions.licenseReport.importers = gocdPluginExtension.licenseReport.importers

--- a/release-task-helper.gradle
+++ b/release-task-helper.gradle
@@ -322,7 +322,6 @@ class GoCDPlugin implements Plugin<Project> {
 
     project.allprojects*.tasks*.findByName('jar').findAll { jar ->
       if (jar == null) return
-      jar.dependsOn("checkLicense")
       jar.into('license-report') {
         from "$pluginProject.extensions.licenseReport.outputDir/THIRD-PARTY-NOTICES.txt"
       }


### PR DESCRIPTION
Previous change in https://github.com/gocd/gocd-plugin-gradle-task-helpers/commit/e51e25ff8480600f5c117ce06c5d9a8ccf8dfc85 doesn't work correctly with multi-project plugin builds (on either Gradle 6 or 7) giving a weird error of `> No value has been specified for property 'allowedLicenseFile'.`

This seems to be because of the project evaluation hijinx going on here. Created #12 to try and look at this again later.

Additionally, this change enables the `excludeBoms` feature added to the license report plugin for use by plugins to remove noise.