### PR TITLE
Use git rev-list with --count option to work around obscure Groovy bug

### DIFF
--- a/version-helper.gradle
+++ b/version-helper.gradle
@@ -22,9 +22,9 @@ static String gitRevision() {
 }
 
 static String distVersion() {
-    def process = "git rev-list HEAD".execute()
+    def process = "git rev-list HEAD --count".execute()
     process.waitFor()
-    return process.text.stripIndent().trim().split("\n").size()
+    return process.text.stripIndent().trim()
 }
 
 static String getLastTag(boolean isExperimental) {


### PR DESCRIPTION
I was setting up an environment to build some parts of the GoCD codebase. For a while I was stuck on running any Gradle commands (e.g. just `gradlew clean`). For a while I was scratching my head, but finally tracked it down to an obscure Groovy bug. Process.text (also known as getText()) can deadlock on commands with long output and only on certain systems. Using `--count` to shorten the output of `git rev-list HEAD` is working on my machine.

(https://issues.apache.org/jira/browse/GROOVY-2305 describes the issue and claims it's fixed. 😕 )

This environment happens to be a Windows machine (😬) which could explain why I was lucky enough to hit this issue!