### PR TITLE
Fixes Gradle 7.X upgrade nags and updates past #13

### DIFF
--- a/archive-task-helper.gradle
+++ b/archive-task-helper.gradle
@@ -18,8 +18,8 @@ allprojects { eachProject ->
   eachProject.afterEvaluate {
     // generate checksums for all archives
     tasks.withType(AbstractArchiveTask) { archiveTask ->
-      includeEmptyDirs false
-      duplicatesStrategy DuplicatesStrategy.EXCLUDE
+      includeEmptyDirs = false
+      duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
       preserveFileTimestamps = false
       reproducibleFileOrder = true
@@ -39,10 +39,10 @@ allprojects { eachProject ->
           attributes(
             'Go-Version': rootProject.extensions.gocdPlugin.goCdVersion,
             'Plugin-Revision': rootProject.extensions.gocdPlugin.pluginVersion,
-            'Implementation-Title': project.name,
-            'Implementation-Version': project.version,
-            'Source-Compatibility': project.java.sourceCompatibility,
-            'Target-Compatibility': project.java.targetCompatibility,
+            'Implementation-Title': eachProject.name,
+            'Implementation-Version': eachProject.version,
+            'Source-Compatibility': eachProject.java.sourceCompatibility,
+            'Target-Compatibility': eachProject.java.targetCompatibility,
             'Git-SHA': rootProject.git.gitRevision(),
           )
         }

--- a/generate-plugin-xml.gradle
+++ b/generate-plugin-xml.gradle
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-private static String xmlTemplate(Project project) {
-  def gocdPlugin = project.gocdPlugin
-
+private static String xmlTemplate(gocdPlugin, version) {
   def targetOsSnippet = ""
 
   if (gocdPlugin.targetOs != null && !gocdPlugin.targetOs.isEmpty()) {
@@ -46,7 +44,7 @@ private static String xmlTemplate(Project project) {
     <go-plugin id="${gocdPlugin.id}" version="1">
       <about>
         <name>${gocdPlugin.name}</name>
-        <version>${project.version}</version>
+        <version>${version}</version>
         <target-go-version>${gocdPlugin.goCdVersion}</target-go-version>
         <description>${gocdPlugin.description}</description>
         <vendor>
@@ -59,8 +57,7 @@ private static String xmlTemplate(Project project) {
     """.stripIndent().trim()
 }
 
-private static String pluginProperties(Project project) {
-  def gocdPlugin = project.gocdPlugin
+private static String pluginProperties(gocdPlugin, version) {
   return """
     #
     # Copyright ${java.time.Year.now().getValue()} ${gocdPlugin.vendorName}
@@ -80,12 +77,17 @@ private static String pluginProperties(Project project) {
 
     id=${gocdPlugin.id}
     name=${gocdPlugin.name}
-    version=${project.version}
+    version=${version}
     goCdVersion=${gocdPlugin.goCdVersion}
     description=${gocdPlugin.description}
     vendorName=${gocdPlugin.vendorName}
     vendorUrl=${gocdPlugin.vendorUrl}
   """.stripIndent().trim()
+}
+
+interface InjectedExecOps {
+    @Inject //@javax.inject.Inject
+    ExecOperations getExecOps()
 }
 
 project.afterEvaluate {
@@ -102,15 +104,18 @@ project.afterEvaluate {
 
 
       pluginProject.tasks.create('generateResources') { thisTask ->
+        def injected = project.objects.newInstance(InjectedExecOps)
         thisTask.outputs.upToDateWhen {false}
         outputs.dir(generatedResourcesOutput)
 
         doFirst {
-          project.delete(generatedResourcesOutput)
+          injected.execOps.exec {
+            commandLine 'rm', '-rf', generatedResourcesOutput
+          }
           generatedResourcesOutput.mkdirs()
 
-          new File(generatedResourcesOutput, "plugin.xml").setText(xmlTemplate(project), "utf-8")
-          new File(generatedResourcesOutput, "plugin.properties").setText(pluginProperties(project), "utf-8")
+          new File(generatedResourcesOutput, "plugin.xml").setText(xmlTemplate(pluginProject.gocdPlugin, pluginProject.version), "utf-8")
+          new File(generatedResourcesOutput, "plugin.properties").setText(pluginProperties(pluginProject.gocdPlugin, pluginProject.version), "utf-8")
         }
       }
 

--- a/release-task-helper.gradle
+++ b/release-task-helper.gradle
@@ -308,6 +308,7 @@ class GoCDPlugin implements Plugin<Project> {
   private void initializeLicenseReporting(GoCDPluginExtension gocdPluginExtension, Project project) {
     Project pluginProject = gocdPluginExtension.pluginProject
     pluginProject.tasks.assemble.dependsOn("checkLicense")
+    project.extensions.licenseReport.outputDir = gocdPluginExtension.licenseReport.outputDir ?: "$project.buildDir/license"
     pluginProject.extensions.licenseReport.outputDir = gocdPluginExtension.licenseReport.outputDir ?: "$project.buildDir/license"
     pluginProject.extensions.licenseReport.projects = gocdPluginExtension.licenseReport.projects ?: project.allprojects
     pluginProject.extensions.licenseReport.configurations = gocdPluginExtension.licenseReport.configurations ?: ["runtimeClasspath"]

--- a/release-task-helper.gradle
+++ b/release-task-helper.gradle
@@ -32,7 +32,7 @@ buildscript {
   dependencies {
     classpath localGroovy()
     classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
-    classpath 'com.github.jk1:gradle-license-report:2.6'
+    classpath 'com.github.jk1:gradle-license-report:2.9'
   }
 }
 

--- a/test-task-helper.gradle
+++ b/test-task-helper.gradle
@@ -37,7 +37,7 @@ allprojects {
 
     testLogging {
       def previousFailed = false
-      exceptionFormat 'full'
+      exceptionFormat = 'full'
 
       beforeSuite { suite ->
         if (suite.name.startsWith("Test Run") || suite.name.startsWith("Gradle Worker")) return


### PR DESCRIPTION
Specifically, #13 and its subsequent rollback. I have ran it with `com.github.jk1:gradle-license-report:2.9` with no issues.