### PR TITLE
Allow dependabot to work on task helper dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 99

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,0 +1,15 @@
+final Map<String, String> libraries = [
+    // Dependabot will parse these dependencies.
+    // Keep all of these as uninterpolated string literals so that Dependabot can parse the versions and create PRs for
+    // upgrades.
+    //
+    // DO NOT interpolate version variables here because Dependabot is not smart enough to understand those. Dependabot's
+    // version parsing is simply regex matching and never actually evaluates a gradle script.
+    gradleLicenseReport: 'com.github.jk1:gradle-license-report:2.9',
+    httpBuilder        : 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1',
+]
+
+ext {
+    //noinspection GroovyAssignabilityCheck
+    deps = libraries
+}

--- a/helper.gradle
+++ b/helper.gradle
@@ -47,6 +47,7 @@ task allDependencies {
     description = "Print dependency tree of all projects"
 }
 
+apply from: (buildscript.sourceFile ? buildscript.sourceFile.toURI() : buildscript.sourceURI).resolve("./dependencies.gradle")
 apply from: (buildscript.sourceFile ? buildscript.sourceFile.toURI() : buildscript.sourceURI).resolve("./version-helper.gradle")
 apply from: (buildscript.sourceFile ? buildscript.sourceFile.toURI() : buildscript.sourceURI).resolve("./generate-plugin-xml.gradle")
 apply from: (buildscript.sourceFile ? buildscript.sourceFile.toURI() : buildscript.sourceURI).resolve("./archive-task-helper.gradle")

--- a/release-task-helper.gradle
+++ b/release-task-helper.gradle
@@ -31,8 +31,8 @@ buildscript {
 
   dependencies {
     classpath localGroovy()
-    classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
-    classpath 'com.github.jk1:gradle-license-report:2.9'
+    classpath project.deps.httpBuilder
+    classpath project.deps.gradleLicenseReport
   }
 }
 


### PR DESCRIPTION
Adds a `dependencies.gradle` workaround to allow us to hopefully keep these dependencies up-to-date.